### PR TITLE
python3 adaption

### DIFF
--- a/calibre_plugin/model.py
+++ b/calibre_plugin/model.py
@@ -8,8 +8,16 @@ __license__ = "GPL v3"
 import datetime
 import json
 import re
-import urllib2
-import urlparse
+
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+    from urllib.parse import urlparse
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
+    import urlparse
+
 
 from PyQt5.Qt import QAbstractTableModel, QCoreApplication, Qt
 


### PR DESCRIPTION
Fixed this

~/src/calibre-opds-client$ calibre
Traceback (most recent call last):
  File "calibre/gui2/ui.py", line 134, in __init__
  File "calibre/gui2/ui.py", line 152, in init_iaction
  File "calibre/customize/__init__.py", line 616, in load_actual_plugin
  File "importlib/__init__.py", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.ui", line 10, in <module>
    from calibre_plugins.opds_client.main import OpdsDialog
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.main", line 32, in <module>
    from calibre_plugins.opds_client.model import OpdsBooksModel
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.model", line 11, in <module>
    import urllib2
ModuleNotFoundError: No module named 'urllib2'
~/src/calibre-opds-client$ calibre
Traceback (most recent call last):
  File "calibre/gui2/ui.py", line 134, in __init__
  File "calibre/gui2/ui.py", line 152, in init_iaction
  File "calibre/customize/__init__.py", line 616, in load_actual_plugin
  File "importlib/__init__.py", line 127, in import_module
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.ui", line 10, in <module>
    from calibre_plugins.opds_client.main import OpdsDialog
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.main", line 32, in <module>
    from calibre_plugins.opds_client.model import OpdsBooksModel
  File "calibre/customize/zipplugin.py", line 192, in exec_module
  File "calibre_plugins.opds_client.model", line 11, in <module>
    import urlparse
ModuleNotFoundError: No module named 'urlparse'

By submitting this pull request, I confirm that my contribution is made under the terms of the GNU General Public License v3.0.

